### PR TITLE
Expose EXTRA_USE_PAYPAL_ACTIONBAR_ICON in settings

### DIFF
--- a/src/android/CardIOCordovaPlugin.java
+++ b/src/android/CardIOCordovaPlugin.java
@@ -74,6 +74,7 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_CONFIRMATION, this.getConfiguration(configurations, "suppressConfirmation", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_HIDE_CARDIO_LOGO, this.getConfiguration(configurations, "hideCardIOLogo", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_SCAN, this.getConfiguration(configurations, "suppressScan", false)); // default: false
+        scanIntent.putExtra(CardIOActivity.EXTRA_USE_PAYPAL_ACTIONBAR_ICON, this.getConfiguration(configurations, "usePaypalActionbarIcon", true)); // default: true
         this.cordova.startActivityForResult(this, scanIntent, REQUEST_CARD_SCAN);
     }
 


### PR DESCRIPTION
Allow for hiding the PayPal logo in the action bar that is displayed when showing the card confirmation page after a successful scan.